### PR TITLE
gophers support

### DIFF
--- a/src/html-tags.c
+++ b/src/html-tags.c
@@ -4153,7 +4153,7 @@ static void prerenderNode(Tag *t, bool opentag)
 					else if (stringEqualCI
 						 (prot, "javascript"))
 						t->javapost = true;
-					else if (stringEqualCI(prot, "https"))
+					else if (stringEqualCI(prot, "https") || stringEqualCI(prot, "gophers"))
 						t->secure = true;
 					else if (!stringEqualCI(prot, "http") &&
 						 !stringEqualCI(prot, "gopher"))

--- a/src/html.c
+++ b/src/html.c
@@ -2382,7 +2382,7 @@ static bool formSubmit(const Tag *form, const Tag *submit, bool dopost, const ch
 	}
 
 skip_encode:
-	if (stringEqualCI(prot, "gopher")) {
+	if (stringEqualCI(prot, "gopher") || stringEqualCI(prot, "gophers")) {
 		requireName = false;
 		fsep = 'g';
 	}
@@ -2871,7 +2871,8 @@ fail:
 				goto fail;
 			}
 		} else if (!stringEqualCI(prot, "https") &&
-			   !stringEqualCI(prot, "gopher")) {
+			   !stringEqualCI(prot, "gopher") &&
+			   !stringEqualCI(prot, "gophers")) {
 			setError(MSG_SubmitProtBad, prot);
 			goto fail;
 		}

--- a/src/html.c
+++ b/src/html.c
@@ -2865,13 +2865,12 @@ fail:
 			if (!validAccount(localAccount))
 				goto fail;
 			form->bymail = true;
-		} else if (stringEqualCI(prot, "http")) {
+		} else if (stringEqualCI(prot, "http") || stringEqualCI(prot, "gopher")) {
 			if (form->secure) {
 				setError(MSG_BecameInsecure);
 				goto fail;
 			}
 		} else if (!stringEqualCI(prot, "https") &&
-			   !stringEqualCI(prot, "gopher") &&
 			   !stringEqualCI(prot, "gophers")) {
 			setError(MSG_SubmitProtBad, prot);
 			goto fail;

--- a/src/http.c
+++ b/src/http.c
@@ -884,7 +884,7 @@ mimestream:
 
 	if (stringEqualCI(prot, "http") || stringEqualCI(prot, "https")) {
 		;		/* ok for now */
-	} else if (stringEqualCI(prot, "gopher")) {
+	} else if (stringEqualCI(prot, "gopher") || stringEqualCI(prot, "gophers")) {
 		return gopherConnect(g);
 	} else if (stringEqualCI(prot, "ftp") ||
 		   stringEqualCI(prot, "ftps") ||
@@ -2185,7 +2185,7 @@ fail:
 static bool gopherConnect(struct i_get *g)
 {
 	CURL *h;		// the curl handle for gopher
-	int protLength;		/* length of "gopher://" */
+	int protLength;		/* length of "gopher://" or "gophers://" */
 	bool transfer_success = false;
 	bool has_slash;
 	char first = 0;

--- a/src/isup.c
+++ b/src/isup.c
@@ -62,6 +62,9 @@ struct PROTOCOL {
 	{"git", 0, false, true, false},
 	{"svn", 0, false, true, false},
 	{"gopher", 70, false, true, true},
+
+// gophers and gopher can share a port which is the curl default
+	{"gophers", 70, false, true, true},
 	{"magnet", 0, false, false, false},
 	{"irc", 0, false, true, false},
 	{"", 0, false, false, false},
@@ -2867,7 +2870,7 @@ and don't run plugins at all. We don't have to check for those.
 *********************************************************************/
 
 	if (memEqualCI(url, "http:/", 6) ||
-	    memEqualCI(url, "https:/", 7) || memEqualCI(url, "gopher:/", 8)) {
+	    memEqualCI(url, "https:/", 7) || memEqualCI(url, "gopher:/", 8) || memEqualCI(url, "gophers:/", 9)) {
 		s = strstr(url, "://");
 		if (!s)		// should never happen
 			s = url;


### PR DESCRIPTION
This is relatively basic, but tested, gophers support. There's no fallback
support as per some documentation about some versions of gopher over TLS but
that's a bigger design problem and at least we can support gophers as per
the Curl implementation.

- **Very basic start on supporting gophers (gopher over tls)**
- **Make secure to insecure form submission behaviour the same for https and gophers**
- **Stick with either gopher or gophers for selectors where we don't change host**
