### PR TITLE
Further clean up (no functional changes)

### DIFF
--- a/src/eb.h
+++ b/src/eb.h
@@ -221,7 +221,7 @@ struct i_get {
  * or case sensitive, so keep our own sanitized copy. */
 	char content[60];
 	char *charset;	/* extra content info such as charset */
-long long hcl;			/* http content length */
+curl_off_t hcl;			/* http content length */
 	char *cdfn;		/* http content disposition file name */
 	time_t modtime;	/* http modification time */
 	char *etag;		/* the etag in the header */

--- a/src/ebprot.h
+++ b/src/ebprot.h
@@ -215,7 +215,7 @@ void rowspan(void);
 // sourcefile=http.c
 void eb_curl_global_init(void);
 void eb_curl_global_cleanup(void);
-size_t eb_curl_callback(char *incoming, size_t size, size_t nitems, struct i_get *g);
+size_t eb_curl_callback(char *incoming, size_t size, size_t nitems, void *data);
 time_t parseHeaderDate(const char *date);
 bool parseRefresh(char *ref, int *delay_p);
 bool shortRefreshDelay(const char *r, int d);

--- a/src/fetchmail.c
+++ b/src/fetchmail.c
@@ -1901,7 +1901,7 @@ static CURL *newFetchmailHandle(const char *username, const char *password)
 	curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT, mailTimeout);
 	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, eb_curl_callback);
 	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &callback_data);
-	curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
+	curl_easy_setopt(handle, CURLOPT_VERBOSE, 1l);
 	curl_easy_setopt(handle, CURLOPT_DEBUGFUNCTION, ebcurl_debug_handler);
 	curl_easy_setopt(handle, CURLOPT_DEBUGDATA, &callback_data);
 
@@ -4283,9 +4283,9 @@ bool imap1rf(void)
 	freeWindows(context, false);
 	if(cw->dol) delText(1, cw->dol);
 // in case you changed debug levels
-	curl_easy_setopt(h, CURLOPT_VERBOSE, (debugLevel >= 4));
+	curl_easy_setopt(h, CURLOPT_VERBOSE, (long) (debugLevel >= 4));
 again:
-	curl_easy_setopt(h, CURLOPT_CUSTOMREQUEST, 0);
+	curl_easy_setopt(h, CURLOPT_CUSTOMREQUEST, NULL);
 	res = getMailData(h);
 	if (res != CURLE_OK) {
 		nzFree(mailstring), mailstring = 0;
@@ -4349,7 +4349,7 @@ bool folderDescend(const char *path, bool rf)
 	struct FOLDER f0;
 	memset(&f0, 0, sizeof(f0));
 	f0.path = rf ? cw->baseDirName : path;
-	curl_easy_setopt(h, CURLOPT_VERBOSE, (debugLevel >= 4));
+	curl_easy_setopt(h, CURLOPT_VERBOSE, (long) (debugLevel >= 4));
 	if(!examineFolder(h, &f0, false)) {
 //Oops, problem.
 		if(rf && cw->dol) delText(1, cw->dol);
@@ -4418,7 +4418,7 @@ bool folderSearch(const char *path, char *search, bool rf)
 		delText(1, cw->dol);
 
 	active_a = a, isimap = true;
-	curl_easy_setopt(h, CURLOPT_VERBOSE, (debugLevel >= 4));
+	curl_easy_setopt(h, CURLOPT_VERBOSE, (long) (debugLevel >= 4));
 // We have to select the folder first, then search
 // Technically we don't have to on refresh, but I will anyways,
 // in case it's been a long time and we logged out and need to reselect.
@@ -5042,7 +5042,7 @@ bool addFolders()
 	uchar *line1, *t;
 	char *line2, *v;
 
-	curl_easy_setopt(h, CURLOPT_VERBOSE, (debugLevel >= 4));
+	curl_easy_setopt(h, CURLOPT_VERBOSE, (long) (debugLevel >= 4));
 	if (linePending) line1 = linePending;
 	else line1 = inputLine(true);
 
@@ -5096,7 +5096,7 @@ bool deleteFolder(int ln)
 	char *v, *p;
 	char inbuf[80];
 
-	curl_easy_setopt(h, CURLOPT_VERBOSE, (debugLevel >= 4));
+	curl_easy_setopt(h, CURLOPT_VERBOSE, (long) (debugLevel >= 4));
 	p = (char*)fetchLine(ln, -1);
 	l = strchr(p, ':') - p; // this should always work
 	p[l] = 0; // I'll put it back
@@ -5131,7 +5131,7 @@ bool renameFolder(const char *src, const char *dest)
 	CURL *h = cw->imap_h;
 	char *v;
 
-	curl_easy_setopt(h, CURLOPT_VERBOSE, (debugLevel >= 4));
+	curl_easy_setopt(h, CURLOPT_VERBOSE, (long) (debugLevel >= 4));
 	asprintf(&v, "RENAME \"%s\" \"%s\"", src, dest);
 	curl_easy_setopt(h, CURLOPT_CUSTOMREQUEST, v);
 	free(v);

--- a/src/fetchmail.c
+++ b/src/fetchmail.c
@@ -4558,7 +4558,7 @@ bool mailDescend(const char *title, char cmd)
 	struct FOLDER f0;
 
 	active_a = a, isimap = true;
-	curl_easy_setopt(h, CURLOPT_VERBOSE, (debugLevel >= 4));
+	curl_easy_setopt(h, CURLOPT_VERBOSE, (long) (debugLevel >= 4));
 	path = cw->baseDirName;
 	f0.path = path; // that's all we need in f0
 

--- a/src/html.c
+++ b/src/html.c
@@ -2409,9 +2409,7 @@ skip_encode:
 			if (t->itype != INP_IMAGE)
 				goto success;
 			namelen = strlen(name);
-			nx = (char *)allocMem(namelen + 3);
-			strcpy(nx, name);
-			strcpy(nx + namelen, ".x");
+			asprintf(&nx, "%s.x", name);
 			postNameVal(nx, "0", fsep, false);
 			nx[namelen + 1] = 'y';
 			postNameVal(nx, "0", fsep, false);

--- a/src/http.c
+++ b/src/http.c
@@ -344,11 +344,9 @@ eb_curl_callback(char *incoming, size_t size, size_t nitems, void *data)
 		if (g->hcl == 0) {
 // http should always set http content length, this is just for ftp.
 // And ftp downloading a file always has state = 1 on the first data block.
-			double d_size = 0.0;	// download size, if we can get it
 			curl_easy_getinfo(g->h,
 					  CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
-					  &d_size);
-			g->hcl = d_size;
+					  &g->hcl);
 			if (g->hcl < 0)
 				g->hcl = 0;
 		}
@@ -965,7 +963,7 @@ mimestream:
 		if (curlret != CURLE_OK)
 			goto curl_fail;
 	} else {
-		curlret = curl_easy_setopt(h, CURLOPT_HTTPGET, 1);
+		curlret = curl_easy_setopt(h, CURLOPT_HTTPGET, 1l);
 		if (curlret != CURLE_OK)
 			goto curl_fail;
 	}
@@ -1298,7 +1296,7 @@ they go where they go, so this doesn't come up very often.
 /* Convert POST request to GET request after redirection. */
 /* This should only be done for 301 through 303 */
 				if (g->code < 307) {
-					curl_easy_setopt(h, CURLOPT_HTTPGET, 1);
+					curl_easy_setopt(h, CURLOPT_HTTPGET, 1l);
 					post_request = false;
 				}
 /* I think there is more work to do for 307 308,
@@ -2434,7 +2432,7 @@ my_curl_safeSocket(void *clientp, curl_socket_t socketfd, curlsocktype purpose)
 static CURL *http_curl_init(struct i_get *g)
 {
 	CURLcode curl_init_status = CURLE_OK;
-	int curl_auth;
+	long curl_auth;
 	CURL *h = curl_easy_init();
 	if (h == NULL)
 		goto libcurl_init_fail;
@@ -3012,7 +3010,7 @@ CURLcode setCurlURL(CURL * h, const char *url)
 		curl_easy_setopt(h, CURLOPT_USERAGENT, agent);
 	}
 	curl_easy_setopt(h, CURLOPT_SSL_VERIFYPEER, verify);
-	curl_easy_setopt(h, CURLOPT_SSL_VERIFYHOST, (verify ? 2 : 0));
+	curl_easy_setopt(h, CURLOPT_SSL_VERIFYHOST, (long) (verify ? 2 : 0));
 // certificate file is per handle, not global, so must be set here.
 // cookie file is however on the global handle, go figure.
 	if (sslCerts)

--- a/src/http.c
+++ b/src/http.c
@@ -197,7 +197,10 @@ static void scan_http_headers(struct i_get *g, bool fromCallback)
 	}
 
 	if (!g->hcl && (v = find_http_header(g, "content-length"))) {
-		sscanf(v, "%lld", &g->hcl);
+                long long cl = 0;
+		sscanf(v, "%lld", &cl);
+// be explicit in case curl_off_t changes
+                g->hcl = (curl_off_t) cl;
 		nzFree(v);
 		if (g->hcl)
 			debugPrint(4, "content length %lld", g->hcl);

--- a/src/http.c
+++ b/src/http.c
@@ -327,8 +327,9 @@ download states, in down_state:
 *********************************************************************/
 
 size_t
-eb_curl_callback(char *incoming, size_t size, size_t nitems, struct i_get * g)
+eb_curl_callback(char *incoming, size_t size, size_t nitems, void *data)
 {
+        struct i_get *g = data;
 	size_t num_bytes = nitems * size;
 	int dots1, dots2, rc;
 


### PR DESCRIPTION
This pr mostly updates data types to the new curl normal with only one small
change to replace an explicit memory allocation and couple of strcpy calls with
an asprintf call to get rid of a warning and slightly simplify things.
